### PR TITLE
Add BuildNavMeshAsync method

### DIFF
--- a/NavMeshComponents/Scripts/NavMeshSurface2d.cs
+++ b/NavMeshComponents/Scripts/NavMeshSurface2d.cs
@@ -199,6 +199,25 @@ namespace UnityEngine.AI
             }
         }
 
+        // Source: https://github.com/Unity-Technologies/NavMeshComponents/issues/97#issuecomment-528692289
+        public AsyncOperation BuildNavMeshAsync()
+        {
+            RemoveData();
+            m_NavMeshData = new NavMeshData(m_AgentTypeID)
+            {
+                name = gameObject.name,
+                position = transform.position,
+                rotation = transform.rotation
+            };
+
+            if (isActiveAndEnabled)
+            {
+                AddData();
+            }
+
+            return UpdateNavMesh(m_NavMeshData);
+        }
+
         public AsyncOperation UpdateNavMesh(NavMeshData data)
         {
             var sources = CollectSources();


### PR DESCRIPTION
The async mesh build is achieved via a method shared here:
https://github.com/Unity-Technologies/NavMeshComponents/issues/97#issuecomment-528692289

Closes #47 

Hey sorry I've been a bit busy, but I'll try to get around to the few issues I raised. It turns out I can't use this method because I pass in a different position, but I figured I'd add it in anyway. 

I've tested it in my project.

Cheers.