### PR TITLE
#80:Fixed Collecting Objects with Multiple Scenes

### DIFF
--- a/NavMeshComponents/Scripts/NavMeshBuilder2d.cs
+++ b/NavMeshComponents/Scripts/NavMeshBuilder2d.cs
@@ -81,12 +81,14 @@ namespace UnityEngine.AI
                 default:
                 {
                     var list = new List<GameObject>();
+                    var testlist = new List<GameObject>();
                     for (int i = 0; i < SceneManager.sceneCount; ++i)
                     {
                         var s = SceneManager.GetSceneAt(i);
                         s.GetRootGameObjects(list);
+                        testlist.AddRange(list);
                     }
-                    return list;
+                    return testlist;
                 }
             }
         }


### PR DESCRIPTION
(UnityVersion 2020.3.14f1):
In NavMeshBuilder2d.cs the old line 87: s.GetRootGameObjects(list); 
does not append to the Object named list but overwrites the content in every loop. So only the latest Scene is checked for rootGameObjects.
To fix this in NavMeshBuilder2d.cs I introduced a second List named testlist and appended the results of each loops Iteration list Object to it via  testlist.AddRange(list);