### PR TITLE
Fix NavMeshBuilder2d for non active RootObjects

### DIFF
--- a/NavMeshComponents/Scripts/NavMeshBuilder2d.cs
+++ b/NavMeshComponents/Scripts/NavMeshBuilder2d.cs
@@ -100,6 +100,7 @@ namespace UnityEngine.AI
         {
             foreach (var it in builder.Root)
             {
+                if(!it.activeSelf){continue;}
                 CollectSources(it, sources, builder);
             }
             if (!builder.hideEditorLogs) Debug.Log("Sources " + sources.Count);


### PR DESCRIPTION
#80 Bonus Bug: Dont collect Objects with non active Parents/Roots. In some cases line 244:
var size = new Vector3(tilemap.layoutGrid.cellSize.x, tilemap.layoutGrid.cellSize.y, 0);
can result in NullReferences as the getter layoutGrid can return null if a Parent/Root of the tilemap are not set to active.