### PR TITLE
Allow for multiple colliders on a single object.

### DIFF
--- a/NavMeshComponents/Scripts/NavMeshBuilder2d.cs
+++ b/NavMeshComponents/Scripts/NavMeshBuilder2d.cs
@@ -141,8 +141,7 @@ namespace NavMeshPlus.Extensions
         {
             if (builder.CollectGeometry == NavMeshCollectGeometry.PhysicsColliders)
             {
-                var collider = modifier.GetComponent<Collider2D>();
-                if (collider != null)
+                foreach (var collider in modifier.GetComponents<Collider2D>())
                 {
                     CollectSources(sources, collider, area, builder);
                 }


### PR DESCRIPTION
When building sources, gets a list of all colliders on an object instead of just the first one.