### PR TITLE
#130 added option to call non-async versions of rebuild 

### DIFF
--- a/NavMeshComponents/Editor/NavMeshAssetManager.cs
+++ b/NavMeshComponents/Editor/NavMeshAssetManager.cs
@@ -124,7 +124,7 @@ namespace NavMeshPlus.Editors.Components
                 var oper = new AsyncBakeOperation();
 
                 oper.bakeData = InitializeBakeData(surf);
-                oper.bakeOperation = surf.UpdateNavMesh(oper.bakeData);
+                oper.bakeOperation = surf.UpdateNavMeshAsync(oper.bakeData);
                 oper.surface = surf;
 
                 m_BakeOperations.Add(oper);


### PR DESCRIPTION
Added option to call non-async versions of rebuild, as doing so causes internal issues with allocations in Unity 2022.2.11f1, 2023.1.0b8, 2023.2.0a7, giving the warning: `deleting an allocation that is older than its permitted lifetime of 4 frames`. Reportedly this is  not just a warning you can ignore, but causes real errors in some build: `https://forum.unity.com/threads/updatenavmeshdataasync-jobtempalloc-lifespan-of-4-frames-schedulejobforeach-buildnavmeshinfo.1385553/`

Also renamed async one to include suffix async, so that's a breaking change there.