### PR TITLE
fix: use DestroyImmediate in editor to prevent unity errors

### DIFF
--- a/NavMeshComponents/Scripts/NavMeshBuilder2d.cs
+++ b/NavMeshComponents/Scripts/NavMeshBuilder2d.cs
@@ -112,12 +112,22 @@ namespace NavMeshPlus.Extensions
                 // TODO: dispose managed state (managed objects).
                 foreach (var item in map)
                 {
+#if UNITY_EDITOR
+                    Object.DestroyImmediate(item.Value);
+#else 
                     Object.Destroy(item.Value);
+#endif
                 }
                 foreach (var item in coliderMap)
                 {
+#if UNITY_EDITOR
+                    Object.DestroyImmediate(item.Value);
+#else 
                     Object.Destroy(item.Value);
+#endif
                 }
+                map.Clear();
+                coliderMap.Clear();
             }
 
             // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.


### PR DESCRIPTION
I noticed a small issue that happened for me on a project in Unity 2021.3.15f.

Every time I baked I would get this error. It didn't seem to break anything was just annoying really. 

<img width="279" alt="Screenshot 2023-04-23 194913" src="https://user-images.githubusercontent.com/7085672/233853486-6b5ed3b1-30c9-492e-b859-bbefac1eb872.png">

So I made a fix locally but thought it might be useful for you. 
I also added the clearing of the maps just to be thorough. 