### PR TITLE
#186 - Adds AffectedAgents field to NavigationModifierTilemap

### DIFF
--- a/NavMeshComponents/Editor/NavMeshModifierTilemapEditor.cs
+++ b/NavMeshComponents/Editor/NavMeshModifierTilemapEditor.cs
@@ -18,10 +18,12 @@ namespace NavMeshPlus.Editors.Components
     [CustomEditor(typeof(NavMeshModifierTilemap))]
     class NavMeshModifierTilemapEditor : Editor
     {
+        SerializedProperty m_AffectedAgents;
         SerializedProperty m_TileModifiers;
 
         void OnEnable()
         {
+            m_AffectedAgents = serializedObject.FindProperty("m_AffectedAgents");
             m_TileModifiers = serializedObject.FindProperty("m_TileModifiers");
         }
 
@@ -30,6 +32,9 @@ namespace NavMeshPlus.Editors.Components
             NavMeshModifierTilemap modifierTilemap = target as NavMeshModifierTilemap;
 
             serializedObject.Update();
+
+            NavMeshComponentsGUIUtility.AgentMaskPopup("Affected Agents", m_AffectedAgents);
+
             EditorGUILayout.PropertyField(m_TileModifiers);
 
             if (modifierTilemap.HasDuplicateTileModifiers())

--- a/NavMeshComponents/Scripts/NavMeshBuilder2d.cs
+++ b/NavMeshComponents/Scripts/NavMeshBuilder2d.cs
@@ -292,6 +292,11 @@ namespace NavMeshPlus.Extensions
 
             var modifierTilemap = tilemap.GetComponent<NavMeshModifierTilemap>();
 
+            if (modifierTilemap && !modifierTilemap.AffectsAgentType(builder.agentID))
+            {
+                return;
+            }
+
             var vec3int = new Vector3Int(0, 0, 0);
 
             var size = new Vector3(tilemap.layoutGrid.cellSize.x, tilemap.layoutGrid.cellSize.y, 0);

--- a/NavMeshComponents/Scripts/NavMeshModifierTilemap.cs
+++ b/NavMeshComponents/Scripts/NavMeshModifierTilemap.cs
@@ -32,6 +32,11 @@ namespace NavMeshPlus.Components
             public int GetHashCode(TileModifier tileModifier) => tileModifier.GetHashCode();
         }
 
+        // List of agent types the modifier is applied for.
+        // Special values: empty == None, m_AffectedAgents[0] =-1 == All.
+        [SerializeField]
+        List<int> m_AffectedAgents = new List<int>(new int[] { -1 });    // Default value is All
+
         [SerializeField]
         List<TileModifier> m_TileModifiers = new List<TileModifier>();
 
@@ -64,6 +69,15 @@ namespace NavMeshPlus.Components
             }
             modifier = new TileModifier();
             return false;
+        }
+
+        public bool AffectsAgentType(int agentTypeID)
+        {
+            if (m_AffectedAgents.Count == 0)
+                return false;
+            if (m_AffectedAgents[0] == -1)
+                return true;
+            return m_AffectedAgents.IndexOf(agentTypeID) != -1;
         }
     }
 }


### PR DESCRIPTION
Updated NavMeshModifierTilemap to contain m_AffectedAgents field and AffectsAgentType method, which gets called in NavMeshBuilder2d to ensure it collects relevant tile sources.