### PR TITLE
Make CollectTilemapSourcesCache2d.cs check exclude unsupported code in pre 2022 versions

### DIFF
--- a/NavMeshComponents/Scripts/CollectTilemapSourcesCache2d.cs
+++ b/NavMeshComponents/Scripts/CollectTilemapSourcesCache2d.cs
@@ -27,6 +27,7 @@ namespace NavMeshPlus.Extensions
             base.Awake();
         }
 
+#if UNITY_EDITOR || UNITY_2022_2_OR_NEWER && UNITY_EDITOR
         private void OnTilemapTileChanged(Tilemap tilemap, Tilemap.SyncTile[] syncTiles)
         {
             if (tilemap == _tilemap)
@@ -51,6 +52,8 @@ namespace NavMeshPlus.Extensions
                 }
             }
         }
+#endif
+
 
         public AsyncOperation UpdateNavMesh(NavMeshData data)
         {
@@ -75,13 +78,17 @@ namespace NavMeshPlus.Extensions
                     _lookup[position] = i;
                 }
             }
+            #if UNITY_EDITOR || UNITY_2022_2_OR_NEWER && UNITY_EDITOR
             Tilemap.tilemapTileChanged -= OnTilemapTileChanged;
             Tilemap.tilemapTileChanged += OnTilemapTileChanged;
+            #endif
         }
 
         protected override void OnDestroy()
         {
+            #if UNITY_EDITOR || UNITY_2022_2_OR_NEWER && UNITY_EDITOR
             Tilemap.tilemapTileChanged -= OnTilemapTileChanged;
+            #endif
             base.OnDestroy();
         }
     }

--- a/NavMeshComponents/Scripts/CollectTilemapSourcesCache2d.cs
+++ b/NavMeshComponents/Scripts/CollectTilemapSourcesCache2d.cs
@@ -27,7 +27,7 @@ namespace NavMeshPlus.Extensions
             base.Awake();
         }
 
-#if UNITY_EDITOR || UNITY_2022_2_OR_NEWER && UNITY_EDITOR
+#if UNITY_EDITOR || UNITY_2022_2_OR_NEWER
         private void OnTilemapTileChanged(Tilemap tilemap, Tilemap.SyncTile[] syncTiles)
         {
             if (tilemap == _tilemap)
@@ -78,7 +78,7 @@ namespace NavMeshPlus.Extensions
                     _lookup[position] = i;
                 }
             }
-            #if UNITY_EDITOR || UNITY_2022_2_OR_NEWER && UNITY_EDITOR
+            #if UNITY_EDITOR || UNITY_2022_2_OR_NEWER
             Tilemap.tilemapTileChanged -= OnTilemapTileChanged;
             Tilemap.tilemapTileChanged += OnTilemapTileChanged;
             #endif
@@ -86,7 +86,7 @@ namespace NavMeshPlus.Extensions
 
         protected override void OnDestroy()
         {
-            #if UNITY_EDITOR || UNITY_2022_2_OR_NEWER && UNITY_EDITOR
+            #if UNITY_EDITOR || UNITY_2022_2_OR_NEWER
             Tilemap.tilemapTileChanged -= OnTilemapTileChanged;
             #endif
             base.OnDestroy();


### PR DESCRIPTION
https://discussions.unity.com/t/build-error-cs0426-the-type-name-synctile-does-not-exist-in-the-type-tilemap/876593/2
Tilemap.tilemapTileChanged is not supported outside the editor in versions of unity before 2022

Fixes #227 