### PR TITLE
Fix obsolete API warnings with version-gated fallbacks

### DIFF
--- a/NavMeshComponents/Editor/NavMeshComponentsGUIUtility.cs
+++ b/NavMeshComponents/Editor/NavMeshComponentsGUIUtility.cs
@@ -7,13 +7,31 @@ namespace NavMeshPlus.Components.Editors
 {
     public static class NavMeshComponentsGUIUtility
     {
+        static string[] GetAreaNames()
+        {
+#if UNITY_6000_0_OR_NEWER
+            return NavMesh.GetAreaNames();
+#else
+            return GameObjectUtility.GetNavMeshAreaNames();
+#endif
+        }
+
+        static int GetAreaFromName(string areaName)
+        {
+#if UNITY_6000_0_OR_NEWER
+            return NavMesh.GetAreaFromName(areaName);
+#else
+            return GameObjectUtility.GetNavMeshAreaFromName(areaName);
+#endif
+        }
+
         public static void AreaPopup(Rect rect, string labelName, SerializedProperty areaProperty)
         {
             var areaIndex = -1;
-            var areaNames = GameObjectUtility.GetNavMeshAreaNames();
+            var areaNames = GetAreaNames();
             for (var i = 0; i < areaNames.Length; i++)
             {
-                var areaValue = GameObjectUtility.GetNavMeshAreaFromName(areaNames[i]);
+                var areaValue = GetAreaFromName(areaNames[i]);
                 if (areaValue == areaProperty.intValue)
                     areaIndex = i;
             }
@@ -28,7 +46,7 @@ namespace NavMeshPlus.Components.Editors
             if (EditorGUI.EndChangeCheck())
             {
                 if (areaIndex >= 0 && areaIndex < areaNames.Length - 2)
-                    areaProperty.intValue = GameObjectUtility.GetNavMeshAreaFromName(areaNames[areaIndex]);
+                    areaProperty.intValue = GetAreaFromName(areaNames[areaIndex]);
                 else if (areaIndex == areaNames.Length - 1)
                     NavMeshEditorHelpers.OpenAreaSettings();
             }

--- a/NavMeshComponents/Scripts/CollectSources2d.cs
+++ b/NavMeshComponents/Scripts/CollectSources2d.cs
@@ -36,7 +36,11 @@ namespace NavMeshPlus.Extensions
 
         private static Bounds CalculateGridWorldBounds(NavMeshSurface surface, Matrix4x4 worldToLocal, Bounds bounds)
         {
+#if UNITY_2022_2_OR_NEWER
+            var grid = FindAnyObjectByType<Grid>();
+#else
             var grid = FindObjectOfType<Grid>();
+#endif
             var tilemaps = grid?.GetComponentsInChildren<Tilemap>();
             if (tilemaps == null || tilemaps.Length < 1)
             {

--- a/NavMeshComponents/Scripts/NavMeshBuilder2d.cs
+++ b/NavMeshComponents/Scripts/NavMeshBuilder2d.cs
@@ -254,7 +254,11 @@ namespace NavMeshPlus.Extensions
 
         public static void CollectSources(List<NavMeshBuildSource> sources, Collider2D collider, int area, NavMeshBuilder2dState builder)
         { 
+#if UNITY_2023_1_OR_NEWER
+            if (collider.compositeOperation != Collider2D.CompositeOperation.None)
+#else
             if (collider.usedByComposite)
+#endif
             {
                 collider = collider.GetComponent<CompositeCollider2D>();
             }

--- a/NavMeshComponents/Scripts/NavMeshLink.cs
+++ b/NavMeshComponents/Scripts/NavMeshLink.cs
@@ -53,20 +53,38 @@ namespace NavMeshPlus.Components
         void OnEnable()
         {
             AddLink();
-            if (m_AutoUpdatePosition && m_LinkInstance.valid)
+            if (m_AutoUpdatePosition && IsLinkValid(m_LinkInstance))
                 AddTracking(this);
         }
 
         void OnDisable()
         {
             RemoveTracking(this);
-            m_LinkInstance.Remove();
+            NavMesh.RemoveLink(m_LinkInstance);
         }
 
         public void UpdateLink()
         {
-            m_LinkInstance.Remove();
+            NavMesh.RemoveLink(m_LinkInstance);
             AddLink();
+        }
+
+        static bool IsLinkValid(NavMeshLinkInstance link)
+        {
+#if UNITY_2023_2_OR_NEWER
+            return NavMesh.IsLinkValid(link);
+#else
+            return link.valid;
+#endif
+        }
+
+        static void SetLinkOwner(NavMeshLinkInstance link, UnityEngine.Object owner)
+        {
+#if UNITY_2023_2_OR_NEWER
+            NavMesh.SetLinkOwner(link, owner);
+#else
+            link.owner = owner;
+#endif
         }
 
         static void AddTracking(NavMeshLink link)
@@ -107,7 +125,7 @@ namespace NavMeshPlus.Components
         void AddLink()
         {
 #if UNITY_EDITOR
-            if (m_LinkInstance.valid)
+            if (IsLinkValid(m_LinkInstance))
             {
                 Debug.LogError("Link is already added: " + this);
                 return;
@@ -123,8 +141,8 @@ namespace NavMeshPlus.Components
             link.area = m_Area;
             link.agentTypeID = m_AgentTypeID;
             m_LinkInstance = NavMesh.AddLink(link, transform.position, transform.rotation);
-            if (m_LinkInstance.valid)
-                m_LinkInstance.owner = this;
+            if (IsLinkValid(m_LinkInstance))
+                SetLinkOwner(m_LinkInstance, this);
 
             m_LastPosition = transform.position;
             m_LastRotation = transform.rotation;
@@ -156,7 +174,7 @@ namespace NavMeshPlus.Components
         {
             m_Width = Mathf.Max(0.0f, m_Width);
 
-            if (!m_LinkInstance.valid)
+            if (!IsLinkValid(m_LinkInstance))
                 return;
 
             UpdateLink();

--- a/NavMeshComponents/Scripts/NavMeshSurface.cs
+++ b/NavMeshComponents/Scripts/NavMeshSurface.cs
@@ -318,6 +318,26 @@ namespace NavMeshPlus.Components
             }
         }
 
+#if UNITY_EDITOR
+        public static void CollectSourcesInStage(Transform root, int includedLayerMask, NavMeshCollectGeometry geometry, int defaultArea, List<NavMeshBuildMarkup> markups, UnityEngine.SceneManagement.Scene stageProxy, List<NavMeshBuildSource> results)
+        {
+#if UNITY_6000_0_OR_NEWER
+            UnityEditor.AI.NavMeshEditorHelpers.CollectSourcesInStage(root, includedLayerMask, geometry, defaultArea, false, markups, false, stageProxy, results);
+#else
+            UnityEditor.AI.NavMeshBuilder.CollectSourcesInStage(root, includedLayerMask, geometry, defaultArea, false, markups, false, stageProxy, results);
+#endif
+        }
+
+        public static void CollectSourcesInStage(Bounds includedWorldBounds, int includedLayerMask, NavMeshCollectGeometry geometry, int defaultArea, List<NavMeshBuildMarkup> markups, UnityEngine.SceneManagement.Scene stageProxy, List<NavMeshBuildSource> results)
+        {
+#if UNITY_6000_0_OR_NEWER
+            UnityEditor.AI.NavMeshEditorHelpers.CollectSourcesInStage(includedWorldBounds, includedLayerMask, geometry, defaultArea, false, markups, false, stageProxy, results);
+#else
+            UnityEditor.AI.NavMeshBuilder.CollectSourcesInStage(includedWorldBounds, includedLayerMask, geometry, defaultArea, false, markups, false, stageProxy, results);
+#endif
+        }
+#endif
+
         List<NavMeshBuildSource> CollectSources(NavMeshBuilderState builderState)
         {
             var sources = new List<NavMeshBuildSource>();
@@ -353,21 +373,18 @@ namespace NavMeshPlus.Components
             {
                 if (m_CollectObjects == CollectObjects.All)
                 {
-                    UnityEditor.AI.NavMeshBuilder.CollectSourcesInStage(
-                        null, m_LayerMask, m_UseGeometry, m_DefaultArea, markups, gameObject.scene, sources);
+                    CollectSourcesInStage(null, m_LayerMask, m_UseGeometry, m_DefaultArea, markups, gameObject.scene, sources);
                 }
                 else if (m_CollectObjects == CollectObjects.Children)
                 {
-                    UnityEditor.AI.NavMeshBuilder.CollectSourcesInStage(
-                        transform, m_LayerMask, m_UseGeometry, m_DefaultArea, markups, gameObject.scene, sources);
+                    CollectSourcesInStage(transform, m_LayerMask, m_UseGeometry, m_DefaultArea, markups, gameObject.scene, sources);
                 }
                 else if (m_CollectObjects == CollectObjects.Volume)
                 {
                     Matrix4x4 localToWorld = Matrix4x4.TRS(transform.position, transform.rotation, Vector3.one);
                     var worldBounds = GetWorldBounds(localToWorld, new Bounds(m_Center, m_Size));
 
-                    UnityEditor.AI.NavMeshBuilder.CollectSourcesInStage(
-                        worldBounds, m_LayerMask, m_UseGeometry, m_DefaultArea, markups, gameObject.scene, sources);
+                    CollectSourcesInStage(worldBounds, m_LayerMask, m_UseGeometry, m_DefaultArea, markups, gameObject.scene, sources);
                 }
                 for (int i = 0; i < NavMeshExtensions.Count; ++i)
                 {


### PR DESCRIPTION
Wrap APIs deprecated in newer Unity versions behind #if directives so the package still compiles on older editors:

- NavMeshBuilder.CollectSourcesInStage -> NavMeshEditorHelpers (6000.0)
- GameObjectUtility.GetNavMeshArea* -> NavMesh.GetArea* (6000.0)
- NavMeshLinkInstance.valid/owner -> NavMesh.IsLinkValid/SetLinkOwner (2023.2)
- Collider2D.usedByComposite -> Collider2D.compositeOperation (2023.1)
- FindObjectOfType -> FindAnyObjectByType (2022.2)

NavMeshLinkInstance.Remove() is replaced with NavMesh.RemoveLink() unconditionally, since the latter predates every supported editor version.